### PR TITLE
[trie] fix: no child node for next letter means word is not found

### DIFF
--- a/trie/trie.py
+++ b/trie/trie.py
@@ -31,4 +31,6 @@ class Trie(object):
                 if node.letter == letter:
                     self.current_node = node
                     break
+            else:
+                return False
         return self.current_node.end_of_word


### PR DESCRIPTION
Fixed a bug in Trie implementation. 

```
$ cat words.txt 
hello
world

$ python trie_tester.py words.txt world
Building the trie data structure...
Trie data structure built...
Searching the word "world"...
Word was found in the trie

before:

$ python trie_tester.py words.txt worldd
Building the trie data structure...
Trie data structure built...
Searching the word "worldd"...
Word was found in the trie

after:

$ python trie_tester.py words.txt worldd
Building the trie data structure...
Trie data structure built...
Searching the word "worldd"...
Word was not found in the trie

```

P.S. Wandering around in search of helpful examples of Elixir code to start hacking on my toy project, and found "icky_venus" repository. Nice and simple enough, just what I needed to grasp basic conceptions. Moved me from the dead point. Thanks!

P.P.S. Simplicity and elegance of bloom filter implementation I found very inspiring too.